### PR TITLE
Improvements to desktop file, metainfo/appdata & README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,18 @@ Please consider donating to help development as this software is completely free
 [![Download on Flathub](https://dl.flathub.org/assets/badges/flathub-badge-en.svg)][flathub]
 
 ## Features
-* Saving as NES format
-* Pencil for Pixel Art
+* Pencil Button for Drawing Pixels
 * Button for Moving Tiles on the Canvas
 * Button for Swapping Tiles
 
 ## NES
-* 4 palettes to choose from, which can be customized.
+* Saving as NES Format
+* 4 palettes to choose from for each bank, which can be customized.
 * Two memory banks for sprites and backgrounds.
 * Showing the color index numbers.
-* Multi screens for saving an assembler code.
-* Two Sprite Modes: 8x8 and 8x16.
+* Multiscreen for saving background and load via assembler code.
+* Megatile Setup
+* Sprite Modes: 8x8 and 8x16.
 
 [flathub]: https://flathub.org/apps/io.github.xverizex.RetroSpriteEditor
 [donate]: https://www.donationalerts.com/r/xverizex

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 # Retro Sprite Editor
 Draw your sprites and backgrounds with this program specially designed for retro consoles.
-### [Consider donating to help this software's development][donate]
+
+## Donate ❤️
+Please consider donating to help development as this software is completely free and open source.
+
+### [Donate Here][donate]
 
 ## Screenshot
 ![screenshot](screenshots/0.png)
@@ -11,9 +15,8 @@ Draw your sprites and backgrounds with this program specially designed for retro
 [![Download on Flathub](https://dl.flathub.org/assets/badges/flathub-badge-en.svg)][flathub]
 
 ## Features
-* Save as NES format
+* Saving as NES format
 * Pencil for Pixel Art
-* Software is FOSS
 * Button for Moving Tiles on the Canvas
 * Button for Swapping Tiles
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,28 @@
-<img style="vertical-align: middle;" src="data/icons/hicolor/scalable/apps/io.github.xverizex.RetroSpriteEditor.svg" width="120" height="120" align="left">
+<img style="vertical-align: middle;" src="data/icons/hicolor/scalable/apps/io.github.xverizex.RetroSpriteEditor.svg" width="128" height="128" align="left">
+
 # Retro Sprite Editor
-
-![screenshot](screenshots/0.png)
-
 Draw your sprites and backgrounds with this program specially designed for retro consoles.
+### [Consider donating to help this software's development][donate]
+
+## Screenshot
+![screenshot](screenshots/0.png)
 
 ## Download
 [![Download on Flathub](https://dl.flathub.org/assets/badges/flathub-badge-en.svg)][flathub]
 
 ## Features
-* saving to NES format
-* pencil for pixel art
-* completely free software
-* The button moving for moving tiles on the canvas.
-* The button swapping for exchange tiles each other.
+* Save as NES format
+* Pencil for Pixel Art
+* Software is FOSS
+* Button for Moving Tiles on the Canvas
+* Button for Swapping Tiles
 
 ## NES
 * 4 palettes to choose from, which can be customized.
 * Two memory banks for sprites and backgrounds.
 * Showing the color index numbers.
 * Multi screens for saving an assembler code.
-* two sprite modes 8x8 and 8x16.
-
-## Donate
-* [Donation Alerts][donate]
+* Two Sprite Modes: 8x8 and 8x16.
 
 [flathub]: https://flathub.org/apps/io.github.xverizex.RetroSpriteEditor
 [donate]: https://www.donationalerts.com/r/xverizex

--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
-# RetroSpriteEditor
+<img style="vertical-align: middle;" src="data/icons/hicolor/scalable/apps/io.github.xverizex.RetroSpriteEditor.svg" width="120" height="120" align="left">
+# Retro Sprite Editor
 
 ![screenshot](screenshots/0.png)
 
 Draw your sprites and backgrounds with this program specially designed for retro consoles.
 
-## FEATURES
+## Download
+[![Download on Flathub](https://dl.flathub.org/assets/badges/flathub-badge-en.svg)][flathub]
+
+## Features
 * saving to NES format
 * pencil for pixel art
 * completely free software
@@ -18,8 +22,8 @@ Draw your sprites and backgrounds with this program specially designed for retro
 * Multi screens for saving an assembler code.
 * two sprite modes 8x8 and 8x16.
 
-## LINKS
-* [flathub](https://flathub.org/apps/io.github.xverizex.RetroSpriteEditor)
-
 ## Donate
-* [Donation Alerts](https://www.donationalerts.com/r/xverizex)
+* [Donation Alerts][donate]
+
+[flathub]: https://flathub.org/apps/io.github.xverizex.RetroSpriteEditor
+[donate]: https://www.donationalerts.com/r/xverizex

--- a/data/io.github.xverizex.RetroSpriteEditor.desktop.in
+++ b/data/io.github.xverizex.RetroSpriteEditor.desktop.in
@@ -4,5 +4,5 @@ Exec=retrospriteeditor
 Icon=io.github.xverizex.RetroSpriteEditor
 Terminal=false
 Type=Application
-Categories=Graphics;GNOME;GTK;
+Categories=Graphics;2DGraphics;GNOME;GTK;
 StartupNotify=true

--- a/data/io.github.xverizex.RetroSpriteEditor.desktop.in
+++ b/data/io.github.xverizex.RetroSpriteEditor.desktop.in
@@ -1,8 +1,8 @@
 [Desktop Entry]
-Name=retrospriteeditor
+Name=Retro Sprite Editor
 Exec=retrospriteeditor
 Icon=io.github.xverizex.RetroSpriteEditor
 Terminal=false
 Type=Application
-Categories=GTK;
+Categories=Graphics;GNOME;GTK;
 StartupNotify=true

--- a/data/io.github.xverizex.RetroSpriteEditor.metainfo.xml.in
+++ b/data/io.github.xverizex.RetroSpriteEditor.metainfo.xml.in
@@ -1,112 +1,133 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version='1.0' encoding='utf-8'?>
 <component type="desktop">
-	<id>io.github.xverizex.RetroSpriteEditor</id>
-	<metadata_license>CC0-1.0</metadata_license>
-	<project_license>GPL-3.0-or-later</project_license>
-	<content_rating type="oars-1.1"/>
-	<name>Retro Sprite Editor</name>
-	<developer_name>Dmitrii Naidolinskii</developer_name>
-	<summary>Pixel Editor for Retro Consoles</summary>
-	<description>
-		<p>Available platforms: NES</p>
-
-		<p>Features for NES:</p>
-		<ul>
-			<li>Multiscreen for saving background and load via assembler code.</li>
-			<li>Button pencil for drawing pixels.</li>
-			<li>Button mov for moving tiles.</li>
-			<li>Button swap for exchange tiles each other.</li>
-			<li>Two banks memory.</li>
-			<li>Four palettes for each bank.</li>
-			<li>Button to copy from background to screen.</li>
-			<li>Megatile setup</li>
-			<li>Sprite modes: 8x8, 8x16</li>
-		</ul>
-	</description>
-	<screenshots>
-		<screenshot type="default">
-			<caption>A Pixel Drawing</caption>
-			<image>https://raw.githubusercontent.com/xverizex/RetroSpriteEditor/0.2.30/screenshots/0.png</image>
-		</screenshot>
-	</screenshots>
-	<releases>
-		<release date="2024-01-03" version="0.2.28">
-			<description>
-				<p>Switch to new UI Design.</p>
-			</description>
-		</release>
-		<release date="2023-12-28" version="0.2.27">
-			<description>
-				<p>Fixed the displaying megatiles on the screen.</p>
-				<p>Fixed overpixelization.</p>
-			</description>
-		</release>
-		<release date="2023-12-25" version="0.2.25">
-			<description>
-				<p>Implemented sprite mode 8x16.</p>
-				<p>Fixed memory leak.</p>
-			</description>
-		</release>
-		<release date="2023-12-22" version="0.2.24">
-			<description>
-				<p>Implemented various of type of export code.</p>
-			</description>
-		</release>
-		<release date="2023-12-21" version="0.2.23">
-			<description>
-				<p>The exporting code is little now.</p>
-			</description>
-		</release>
-		<release date="2023-12-21" version="0.2.21">
-			<description>
-				<p>Fixed the copying from background to screen.</p>
-			</description>
-		</release>
-		<release date="2023-12-18" version="0.2.20">
-			<description>
-				<p>Fixed the megatile palette export to nes as asm code.</p>
-			</description>
-		</release>
-		<release date="2023-12-18" version="0.2.10">
-			<description>
-				<p>Added two button. The moving tile and the swap tile.</p>
-				<p>Added import NES CHR.</p>
-			</description>
-		</release>
-		<release date="2023-12-17" version="0.2.8">
-			<description>
-				<p>Added multiscreen saving.</p>
-			</description>
-		</release>
-		<release date="2023-12-17" version="0.2.6">
-			<description>
-				<p>Fixed exporting to asm code.</p>
-			</description>
-		</release>
-		<release date="2023-12-15" version="0.2.4">
-			<description>
-				<p>Added feature to clear tiles on screen.</p>
-			</description>
-		</release>
-		<release date="2023-12-15" version="0.2.2">
-			<description>
-				<p>Added posibility to set screen NES and export to ca65.</p>
-			</description>
-		</release>
-		<release date="2023-12-8" version="0.1.30">
-			<description>
-				<p>Fix little bugs.</p>
-			</description>
-		</release>
-		<release date="2023-12-7" version="0.1.22">
-			<description>
-				<p>The first version with NES support to draw.</p>
-			</description>
-		</release>
-	</releases>
-	<update_contact>horisontdawn@yandex.ru</update_contact>
-	<url type="homepage">https://github.com/xverizex/RetroSpriteEditor</url>
-	<url type="donation">https://www.donationalerts.com/r/xverizex</url>
-	<url type="bugtracker">https://github.com/xverizex/RetroSpriteEditor/issues</url>
+  <id>io.github.xverizex.RetroSpriteEditor</id>
+  <name>Retro Sprite Editor</name>
+  <summary>Pixel Editor for Retro Consoles</summary>
+  <developer_name>Dmitrii Naidolinskii</developer_name>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <update_contact>horisontdawn@yandex.ru</update_contact>
+  <description>
+    <p>Available platforms: NES</p>
+    <p>Features:</p>
+    <ul>
+      <li>Pencil Button for Drawing Pixels</li>
+      <li>Button for Moving Tiles on the Canvas</li>
+      <li>Button for Swapping Tiles</li>
+    </ul>
+    <p>Features for NES:</p>
+    <ul>
+      <li>Saving as NES Format</li>
+      <li>Multiscreen for saving background and load via assembler code.</li>
+      <li>Two memory banks for sprites and backgrounds.</li>
+      <li>4 palettes to choose from for each bank, which can be customized.</li>
+      <li>Button to copy from background to screen.</li>
+      <li>Megatile Setup</li>
+      <li>Sprite Modes: 8x8, 8x16</li>
+    </ul>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <caption>A Pixel Drawing</caption>
+      <image type="source">https://raw.githubusercontent.com/xverizex/RetroSpriteEditor/0.2.30/screenshots/0.png</image>
+    </screenshot>
+  </screenshots>
+  <releases>
+    <release version="0.2.28" date="2024-01-03" type="stable">
+      <description>
+        <p>Switch to new UI Design.</p>
+      </description>
+    </release>
+    <release version="0.2.27" date="2023-12-28" type="stable">
+      <description>
+        <p>Fixed the displaying megatiles on the screen.</p>
+        <p>Fixed overpixelization.</p>
+      </description>
+    </release>
+    <release version="0.2.25" date="2023-12-25" type="stable">
+      <description>
+        <p>Implemented sprite mode 8x16.</p>
+        <p>Fixed memory leak.</p>
+      </description>
+    </release>
+    <release version="0.2.24" date="2023-12-22" type="stable">
+      <description>
+        <p>Implemented various of type of export code.</p>
+      </description>
+    </release>
+    <release version="0.2.23" date="2023-12-21" type="stable">
+      <description>
+        <p>The exporting code is little now.</p>
+      </description>
+    </release>
+    <release version="0.2.21" date="2023-12-21" type="stable">
+      <description>
+        <p>Fixed the copying from background to screen.</p>
+      </description>
+    </release>
+    <release version="0.2.20" date="2023-12-18" type="stable">
+      <description>
+        <p>Fixed the megatile palette export to nes as asm code.</p>
+      </description>
+    </release>
+    <release version="0.2.10" date="2023-12-18" type="stable">
+      <description>
+        <p>Added two button. The moving tile and the swap tile.</p>
+        <p>Added import NES CHR.</p>
+      </description>
+    </release>
+    <release version="0.2.8" date="2023-12-17" type="stable">
+      <description>
+        <p>Added multiscreen saving.</p>
+      </description>
+    </release>
+    <release version="0.2.6" date="2023-12-17" type="stable">
+      <description>
+        <p>Fixed exporting to asm code.</p>
+      </description>
+    </release>
+    <release version="0.2.4" date="2023-12-15" type="stable">
+      <description>
+        <p>Added feature to clear tiles on screen.</p>
+      </description>
+    </release>
+    <release version="0.2.2" date="2023-12-15" type="stable">
+      <description>
+        <p>Added posibility to set screen NES and export to ca65.</p>
+      </description>
+    </release>
+    <release version="0.1.30" date="2000-01-01" type="stable">
+      <description>
+        <p>Fix little bugs.</p>
+      </description>
+    </release>
+    <release version="0.1.22" date="2000-01-01" type="stable">
+      <description>
+        <p>The first version with NES support to draw.</p>
+      </description>
+    </release>
+  </releases>
+  <url type="homepage">https://github.com/xverizex/RetroSpriteEditor</url>
+  <url type="bugtracker">https://github.com/xverizex/RetroSpriteEditor/issues</url>
+  <url type="donation">https://www.donationalerts.com/r/xverizex</url>
   <url type="vcs-browser">https://github.com/xverizex/RetroSpriteEditor</url>
+  <categories>
+    <category>Graphics</category>
+    <category>2DGraphics</category>
+  </categories>
+  <content_rating type="oars-1.1"/>
+  <provides>
+    <binary>retrospriteeditor</binary>
+    <id>io.github.xverizex.RetroSpriteEditor</id>
+  </provides>
+  <keywords>
+    <keyword>2D</keyword>
+    <keyword>2D Graphics</keyword>
+    <keyword>Graphics</keyword>
+    <keyword>Retro</keyword>
+    <keyword>Retro Art</keyword>
+    <keyword>Pixel Art</keyword>
+    <keyword>NES</keyword>
+    <keyword>Console</keyword>
+  </keywords>
 </component>

--- a/data/io.github.xverizex.RetroSpriteEditor.metainfo.xml.in
+++ b/data/io.github.xverizex.RetroSpriteEditor.metainfo.xml.in
@@ -25,7 +25,7 @@
 	</description>
 	<screenshots>
 		<screenshot type="default">
-		  <caption>Main Window with a drawing</caption>
+			<caption>A Pixel Drawing</caption>
 			<image>https://raw.githubusercontent.com/xverizex/RetroSpriteEditor/0.2.30/screenshots/0.png</image>
 		</screenshot>
 	</screenshots>

--- a/data/io.github.xverizex.RetroSpriteEditor.metainfo.xml.in
+++ b/data/io.github.xverizex.RetroSpriteEditor.metainfo.xml.in
@@ -6,10 +6,11 @@
 	<content_rating type="oars-1.1"/>
 	<name>Retro Sprite Editor</name>
 	<developer_name>Dmitrii Naidolinskii</developer_name>
-	<summary>The pixel editor for retro consoles.</summary>
+	<summary>Pixel Editor for Retro Consoles</summary>
 	<description>
-	  <p>The drawing tool for retro consoles.</p>
-		<p>Features for NES:</p> 
+		<p>Available platforms: NES</p>
+
+		<p>Features for NES:</p>
 		<ul>
 			<li>Multiscreen for saving background and load via assembler code.</li>
 			<li>Button pencil for drawing pixels.</li>
@@ -21,12 +22,11 @@
 			<li>Megatile setup</li>
 			<li>Sprite modes: 8x8, 8x16</li>
 		</ul>
-
-		<p>Available platforms: NES</p>
 	</description>
 	<screenshots>
 		<screenshot type="default">
-			<image>https://i.imgur.com/mqKb7r0.png</image>
+		  <caption>Main Window with a drawing</caption>
+			<image>https://raw.githubusercontent.com/xverizex/RetroSpriteEditor/0.2.30/screenshots/0.png</image>
 		</screenshot>
 	</screenshots>
 	<releases>
@@ -108,4 +108,5 @@
 	<url type="homepage">https://github.com/xverizex/RetroSpriteEditor</url>
 	<url type="donation">https://www.donationalerts.com/r/xverizex</url>
 	<url type="bugtracker">https://github.com/xverizex/RetroSpriteEditor/issues</url>
+  <url type="vcs-browser">https://github.com/xverizex/RetroSpriteEditor</url>
 </component>


### PR DESCRIPTION
Changed/Fixed grammar in some places, moved the donate section to the top, changed all-caps words, and make the README look a bit better in general.

Fixed the app from showing in the start menu/launcher as 'retrospriteeditor'

Add vcs-browser to metainfo (which basically takes you to the app source code)

Add 'Graphics' and '2DGraphics' categories to the metainfo & desktop file

Add keywords in the metainfo: 
```
  <keywords>
    <keyword>2D</keyword>
    <keyword>2D Graphics</keyword>
    <keyword>Graphics</keyword>
    <keyword>Retro</keyword>
    <keyword>Retro Art</keyword>
    <keyword>Pixel Art</keyword>
    <keyword>NES</keyword>
    <keyword>Console</keyword>
  </keywords>
```

Probably more changes that I haven't listed here, and obviously feel free to change anything to your liking.