### PR TITLE
Changes & Overall improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Flathub](https://img.shields.io/flathub/v/io.github.xverizex.RetroSpriteEditor?logo=flathub&logoColor=white&label=Flathub)][flathub]
+[![Flathub Installs](https://img.shields.io/flathub/downloads/io.github.xverizex.RetroSpriteEditor?logo=flathub&logoColor=white&label=Installs)][flathub]
+
 <img style="vertical-align: middle;" src="data/icons/hicolor/scalable/apps/io.github.xverizex.RetroSpriteEditor.svg" width="128" height="128" align="left">
 
 # Retro Sprite Editor
@@ -15,11 +18,13 @@ Please consider donating to help development as this software is completely free
 [![Download on Flathub](https://dl.flathub.org/assets/badges/flathub-badge-en.svg)][flathub]
 
 ## Features
+
+### Non-Platform Specific
 * Pencil Button for Drawing Pixels
 * Button for Moving Tiles on the Canvas
 * Button for Swapping Tiles
 
-## NES
+### NES
 * Saving as NES Format
 * 4 palettes to choose from for each bank, which can be customized.
 * Two memory banks for sprites and backgrounds.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 <img style="vertical-align: middle;" src="data/icons/hicolor/scalable/apps/io.github.xverizex.RetroSpriteEditor.svg" width="128" height="128" align="left">
 
 # Retro Sprite Editor
-Draw your sprites and backgrounds with this program specially designed for retro consoles.
+Draw your sprites and backgrounds with this program specially designed for retro consoles.</br>[Features](#features) · [Download](#download) · [New Issue](https://codeberg.org/SOrg/Doggo/issues/new/choose)
 
 ## Donate ❤️
 Please consider donating to help development as this software is completely free and open source.

--- a/data/io.github.xverizex.RetroSpriteEditor.metainfo.xml.in
+++ b/data/io.github.xverizex.RetroSpriteEditor.metainfo.xml.in
@@ -15,7 +15,7 @@
       <li>Button for Moving Tiles on the Canvas</li>
       <li>Button for Swapping Tiles</li>
     </ul>
-    <p>Features for NES platform:</p>
+    <p>Features for NES Platform:</p>
     <ul>
       <li>Saving as NES Format</li>
       <li>Multiscreen for saving background and load via assembler code.</li>

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,3 +1,5 @@
+subdir('icons')
+
 desktop_file = i18n.merge_file(
         input: 'io.github.xverizex.RetroSpriteEditor.desktop.in',
        output: 'io.github.xverizex.RetroSpriteEditor.desktop',
@@ -32,5 +34,3 @@ compile_schemas = find_program('glib-compile-schemas', required: false, disabler
 test('Validate schema file',
      compile_schemas,
      args: ['--strict', '--dry-run', meson.current_source_dir()])
-
-subdir('icons')

--- a/meson.build
+++ b/meson.build
@@ -4,12 +4,17 @@ project('retrospriteeditor', 'c',
   default_options: [ 'werror=false', 'c_std=gnu99', ],
 )
 
+application_name = 'Retro Sprite Editor'
+developer_name = 'xverizex'
+
 i18n = import('i18n')
 gnome = import('gnome')
 cc = meson.get_compiler('c')
 
 config_h = configuration_data()
+config_h.set_quoted('APPLICATION_NAME', application_name)
 config_h.set_quoted('PACKAGE_VERSION', meson.project_version())
+config_h.set_quoted('DEVELOPER_NAME', developer_name)
 config_h.set_quoted('GETTEXT_PACKAGE', 'retrospriteeditor')
 config_h.set_quoted('LOCALEDIR', get_option('prefix') / get_option('localedir'))
 configure_file(output: 'config.h', configuration: config_h)

--- a/src/main-window.c
+++ b/src/main-window.c
@@ -454,14 +454,17 @@ main_window_create_nes_widgets (MainWindow *self)
 	global_type_palette_set_cur (NO_PLATFORM, 0);
 
 	self->hbox_nes_title_buttons = gtk_box_new (GTK_ORIENTATION_HORIZONTAL, 10);
-	self->btn_nes_pixel_drawing = g_object_new (GTK_TYPE_TOGGLE_BUTTON, "label", "DRAWING", NULL);
-	self->btn_nes_screen = g_object_new (GTK_TYPE_TOGGLE_BUTTON, "label", "SCREEN", NULL);
+	self->btn_nes_pixel_drawing = g_object_new (GTK_TYPE_TOGGLE_BUTTON, "label", "Drawing", NULL);
+	self->btn_nes_screen = g_object_new (GTK_TYPE_TOGGLE_BUTTON, "label", "Screen", NULL);
 
 	gtk_box_append (GTK_BOX (self->hbox_nes_title_buttons), self->btn_nes_pixel_drawing);
 	gtk_box_append (GTK_BOX (self->hbox_nes_title_buttons), self->btn_nes_screen);
 
 	adw_header_bar_set_title_widget (ADW_HEADER_BAR (self->header_bar),
 			self->hbox_nes_title_buttons);
+
+	// Make the Header Bar use the flat design without the new stuff
+	gtk_widget_add_css_class (GTK_WIDGET (self->header_bar), "flat");
 
 	gtk_toggle_button_set_group (GTK_TOGGLE_BUTTON (self->btn_nes_pixel_drawing),
 			GTK_TOGGLE_BUTTON (self->btn_nes_screen));
@@ -482,6 +485,7 @@ action_new_project_nes (GSimpleAction *simple,
 		gpointer user_data)
 {
 	MainWindow *self = MAIN_WINDOW (user_data);
+        gtk_window_set_transient_for (GTK_WINDOW (self->new_project_nes_window), GTK_WINDOW(self));
 	gtk_window_present (GTK_WINDOW (self->new_project_nes_window));
 }
 
@@ -539,6 +543,7 @@ main_window_init (MainWindow *self)
 	g_menu_append_submenu (menu_root, "Import", G_MENU_MODEL (menu_import));
 	g_menu_append (menu_root, "Save", "win.save_project");
 	g_menu_append (menu_root, "Export", "win.export");
+	g_menu_append (menu_root, "About Retro Sprite Editor", "app.about");
 
 	self->new_project_nes_window = g_object_new (NES_TYPE_NEW_PROJECT,
 			NULL);
@@ -546,7 +551,8 @@ main_window_init (MainWindow *self)
 	gtk_menu_button_set_menu_model (GTK_MENU_BUTTON (self->menu_button), G_MENU_MODEL (menu_root));
 
   self->header_bar = adw_header_bar_new ();
-  adw_header_bar_set_decoration_layout (ADW_HEADER_BAR (self->header_bar), "icon:minimize,maximize,close");
+  // The app should respect the decor layout the user has set as there is not any obvious reason to force minimize, maximize & close buttons.
+  //adw_header_bar_set_decoration_layout (ADW_HEADER_BAR (self->header_bar), "icon:minimize,maximize,close");
   adw_header_bar_set_show_end_title_buttons (ADW_HEADER_BAR (self->header_bar), TRUE);
 	adw_header_bar_pack_end (ADW_HEADER_BAR (self->header_bar), self->menu_button);
 

--- a/src/main.c
+++ b/src/main.c
@@ -34,6 +34,8 @@ main (int   argc,
 	bindtextdomain (GETTEXT_PACKAGE, LOCALEDIR);
 	bind_textdomain_codeset (GETTEXT_PACKAGE, "UTF-8");
 	textdomain (GETTEXT_PACKAGE);
+	// Make sure all windows from this app use the same WM_CLASS as the main window does. (Shows the right icon for child windows on desktops like KDE Plasma)
+	g_set_prgname ("io.github.xverizex.RetroSpriteEditor");
 
 	app = retro_app_new ("io.github.xverizex.RetroSpriteEditor", G_APPLICATION_DEFAULT_FLAGS);
 	ret = g_application_run (G_APPLICATION (app), argc, argv);

--- a/src/resources/pencil-old.svg
+++ b/src/resources/pencil-old.svg
@@ -7,8 +7,8 @@
    viewBox="0 0 48 48"
    version="1.1"
    id="svg1"
-   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25)"
-   sodipodi:docname="pencil-adaptive.svg"
+   inkscape:version="1.3.1 (91b66b0783, 2023-11-16)"
+   sodipodi:docname="pencil.svg"
    inkscape:export-filename="pencil.png"
    inkscape:export-xdpi="96"
    inkscape:export-ydpi="96"
@@ -19,34 +19,33 @@
   <sodipodi:namedview
      id="namedview1"
      pagecolor="#ffffff"
+     bordercolor="#000000"
      borderopacity="0.25"
      inkscape:showpageshadow="2"
      inkscape:pageopacity="0.0"
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#d1d1d1"
      inkscape:document-units="px"
-     inkscape:zoom="14.230524"
-     inkscape:cx="14.827283"
-     inkscape:cy="23.365268"
+     inkscape:zoom="3.557631"
+     inkscape:cx="-34.714112"
+     inkscape:cy="51.298181"
      inkscape:window-width="1920"
      inkscape:window-height="1011"
-     inkscape:window-x="35"
+     inkscape:window-x="1920"
      inkscape:window-y="32"
-     inkscape:window-maximized="0"
-     inkscape:current-layer="layer1"
-     bordercolor="#000000" />
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
   <defs
      id="defs1" />
   <g
      inkscape:label="Layer 1"
      inkscape:groupmode="layer"
-     id="layer1"
-     transform="matrix(1.2890564,0,0,1.2922328,-7.1140607,-5.8542662)">
+     id="layer1">
     <g
        id="g1"
-       transform="matrix(0.99990885,0,0,1.0020856,-3.5444754,2.999103)">
+       transform="translate(-3.3740909,2.8479368)">
       <rect
-         style="fill:none;stroke:#a1a1a1;stroke-width:2.71454;stroke-dasharray:none;stroke-opacity:1"
+         style="fill:none;stroke:#000000;stroke-width:2;stroke-dasharray:none;stroke-opacity:1"
          id="rect1"
          width="32.806629"
          height="12.290664"
@@ -56,7 +55,7 @@
          transform="rotate(-45)" />
       <path
          id="path1"
-         style="fill:none;stroke:#a1a1a1;stroke-width:2.80395;stroke-dasharray:none;stroke-opacity:1"
+         style="fill:none;stroke:#000000;stroke-width:2"
          inkscape:transform-center-x="-0.95517827"
          inkscape:transform-center-y="-0.9551781"
          transform="matrix(0.85730799,-0.22971498,0.22971498,0.85730799,22.100438,17.631492)"

--- a/src/resources/swap.svg
+++ b/src/resources/swap.svg
@@ -26,13 +26,13 @@
      inkscape:pagecheckerboard="0"
      inkscape:deskcolor="#d1d1d1"
      inkscape:document-units="px"
-     inkscape:zoom="5.03125"
-     inkscape:cx="11.428571"
-     inkscape:cy="33.093168"
+     inkscape:zoom="14.230524"
+     inkscape:cx="12.156966"
+     inkscape:cy="23.927439"
      inkscape:window-width="1920"
      inkscape:window-height="1011"
-     inkscape:window-x="1920"
-     inkscape:window-y="32"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
      inkscape:window-maximized="1"
      inkscape:current-layer="layer1" />
   <defs
@@ -42,7 +42,7 @@
      inkscape:groupmode="layer"
      id="layer1">
     <rect
-       style="fill:#373737;stroke:#000000;stroke-width:2.00801;stroke-opacity:1;fill-opacity:1"
+       style="fill:#717171;stroke:#000000;stroke-width:2.00801;stroke-opacity:1;fill-opacity:1"
        id="rect1"
        width="29.991983"
        height="29.991987"

--- a/src/retro-app.c
+++ b/src/retro-app.c
@@ -1,4 +1,4 @@
-/* retrospriteeditor-application.c
+/* retro-app.c
  *
  * Copyright 2023 vi
  *
@@ -71,22 +71,46 @@ retro_app_about_action (GSimpleAction *action,
                                             GVariant      *parameter,
                                             gpointer       user_data)
 {
-	static const char *developers[] = {"xverizex", NULL};
+	static const char *developers[] = {"xverizex <horisontdawn@yandex.ru>", NULL};
 	RetroApp *self = user_data;
 	GtkWindow *window = NULL;
-
-	g_assert (RETRO_IS_APP (self));
+	GtkWidget *about;
 
 	window = gtk_application_get_active_window (GTK_APPLICATION (self));
 
-	adw_show_about_window (window,
-	                       "application-name", "retrospriteeditor",
-	                       "application-icon", "io.github.xverizex.RetroSpriteEditor",
-	                       "developer-name", "xverizex",
-	                       "version", "0.1.0",
-	                       "developers", developers,
-	                       "copyright", "© 2023 xverizex",
-	                       NULL);
+	g_assert (RETRO_IS_APP (self));
+
+	about = adw_about_window_new ();
+	gtk_window_set_transient_for (GTK_WINDOW (about), window);
+
+	adw_about_window_set_license_type (ADW_ABOUT_WINDOW(about), GTK_LICENSE_GPL_3_0);
+	adw_about_window_set_application_name (ADW_ABOUT_WINDOW(about), APPLICATION_NAME);
+	adw_about_window_set_application_icon (ADW_ABOUT_WINDOW(about), "io.github.xverizex.RetroSpriteEditor");
+	adw_about_window_set_version (ADW_ABOUT_WINDOW(about), PACKAGE_VERSION);
+	adw_about_window_set_developers (ADW_ABOUT_WINDOW(about), developers);
+	adw_about_window_set_developer_name (ADW_ABOUT_WINDOW(about), DEVELOPER_NAME);
+	adw_about_window_set_copyright (ADW_ABOUT_WINDOW(about), "© 2023 xverizex");
+	adw_about_window_set_comments (ADW_ABOUT_WINDOW(about), "Pixel Editor for Retro Consoles");
+	adw_about_window_set_issue_url (ADW_ABOUT_WINDOW(about), "https://github.com/xverizex/RetroSpriteEditor/issues/new/choose");
+	adw_about_window_add_link (ADW_ABOUT_WINDOW (about),
+                                    "_Donate",
+                              "https://www.donationalerts.com/r/xverizex");
+	adw_about_window_add_link (ADW_ABOUT_WINDOW (about),
+                                    "_Source Code",
+                              "https://github.com/xverizex/RetroSpriteEditor");
+
+	gtk_window_present (GTK_WINDOW (about));
+
+        // Left this here in case.. uhh... uhhhhm....
+	//adw_show_about_window (window,
+	//                       "application-name", APPLICATION_NAME,
+	//                       "application-icon", "io.github.xverizex.RetroSpriteEditor",
+	//                       "developer-name", "xverizex",
+	//                       "version", PACKAGE_VERSION,
+	//                       "developers", developers,
+        //                       "comments", "Pixel Editor for Retro Consoles",
+	//                       "copyright", "© 2023 xverizex",
+	//                       NULL);
 }
 
 static void
@@ -116,4 +140,8 @@ retro_app_init (RetroApp *self)
 	gtk_application_set_accels_for_action (GTK_APPLICATION (self),
 	                                       "app.quit",
 	                                       (const char *[]) { "<primary>q", NULL });
+
+	gtk_application_set_accels_for_action (GTK_APPLICATION (self),
+	                                       "app.about",
+	                                       (const char *[]) { "F1", NULL });
 }

--- a/src/retro-app.h
+++ b/src/retro-app.h
@@ -1,4 +1,4 @@
-/* retrospriteeditor-application.h
+/* retro-app.h
  *
  * Copyright 2023 vi
  *

--- a/src/retro-canvas.c
+++ b/src/retro-canvas.c
@@ -1,4 +1,4 @@
-/* main-canvas.c
+/* retro-canvas.c
  *
  * Copyright 2023 vi
  *

--- a/src/retro-canvas.h
+++ b/src/retro-canvas.h
@@ -1,4 +1,4 @@
-/* main-canvas.h
+/* retro-canvas.h
  *
  * Copyright 2023 vi
  *

--- a/src/retrospriteeditor.gresource.xml
+++ b/src/retrospriteeditor.gresource.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
-	<gresource prefix="/io/github/xverizex/RetroSpriteEditor/icons/scalable/actions">
+	<gresource prefix="/io/github/xverizex/RetroSpriteEditor/icons/scalable/actions/">
     <file alias="pencil.svg">resources/pencil.svg</file>
+    <file alias="pencil-old.svg">resources/pencil-old.svg</file>
     <file alias="mov.svg">resources/mov.svg</file>
     <file alias="swap.svg">resources/swap.svg</file>
   </gresource>


### PR DESCRIPTION
## README:
Add Flathub Version & Flathub Installs badges
Make the NES section a sorta mini-section thing (I am tired)
Add navigation link things (still tired, awake at around 11:20)
## :hammer_and_wrench: Preview :hammer_and_wrench:
[![Flathub](https://img.shields.io/flathub/v/io.github.xverizex.RetroSpriteEditor?logo=flathub&logoColor=white&label=Flathub)][flathub] [![Flathub Installs](https://img.shields.io/flathub/downloads/io.github.xverizex.RetroSpriteEditor?logo=flathub&logoColor=white&label=Installs)][flathub]

<img style="vertical-align: middle;" src="https://raw.githubusercontent.com/xverizex/RetroSpriteEditor/master/data/icons/hicolor/scalable/apps/io.github.xverizex.RetroSpriteEditor.svg" width="128" height="128" align="left">

# Retro Sprite Editor
Draw your sprites and backgrounds with this program specially designed for retro consoles.</br>[Features](#features) · [Download](#download) · [New Issue](https://codeberg.org/SOrg/Doggo/issues/new/choose)

## Donate ❤️
Please consider donating to help development as this software is completely free and open source.

### [Donate Here][donate]

## :hammer_and_wrench: End Preview :hammer_and_wrench:

## Metainfo/Appdata:
Make the 'p' uppercase in "Features for NES ***p***latform"

## The app itself

### Meson:
Add `APPLICATION_NAME` & `DEVELOPER_NAME` to config.h

### User Interface
Make AdwHeaderBar use the modern flat design without the AdwToolbarView stuff (probably should try it eventually though)

Make use of AdwAboutWindow with the version changing automatically with the meson version (thanks to `PACKAGE_VERSION` in config.h)

Don't force minimize and maximize buttons and instead respect the user's choice.

Make sure any child window spawned from the app uses the same WM_CLASS:
```
// Make sure all windows from this app use the same WM_CLASS as the main window does. (Shows the right icon for child windows on desktops like KDE Plasma)
g_set_prgname ("io.github.xverizex.RetroSpriteEditor");
```
Change pencil & swap icon colours to look nice on **both dark and light mode**

### Once again, there could be things I have missed/not included, and also feel free to change anything.

[flathub]: https://flathub.org/apps/io.github.xverizex.RetroSpriteEditor
[donate]: https://www.donationalerts.com/r/xverizex